### PR TITLE
Fix CORS policy error

### DIFF
--- a/pkg/server/ping.go
+++ b/pkg/server/ping.go
@@ -57,6 +57,7 @@ func ping() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodOptions {
 			w.Header().Set("Access-Control-Allow-Origin", "*")
+                        w.Header().Set("Access-Control-Allow-Headers", "*")
 			return
 		}
 
@@ -95,6 +96,7 @@ func ping() http.Handler {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Access-Control-Allow-Origin", "*")
+                w.Header().Set("Access-Control-Allow-Headers", "*")
 		_, _ = w.Write(respBytes)
 	})
 }


### PR DESCRIPTION
First of all I would like to thank you for a nice latency service project! It's really useful.

This PR fixes CORS policy error which can arise when user is using Chrome Incognito mode (and other cases).
See error below:
```
Access to XMLHttpRequest at 'https://xxxx.com/ping' from origin 'https://xxxx.com' has been blocked by CORS policy: Request header field accept-language is not allowed by Access-Control-Allow-Headers in preflight response.
```